### PR TITLE
Die Weight values can now be floating point values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ We apply the sum operation on the dice.
 
 You can change the output to show a different number of decimal places (default is 2).
 ```
-➔ # python dice_distro.py -d 6 -n 2 --percent-decimal-place 4 --apply sum
-➔ python dice_distro.py -d 6 -n 2 -pdp 4 --apply sum
+➔ # python dice_distro.py -d 6 -n 2 --result-decimal-place 4 --apply sum
+➔ python dice_distro.py -d 6 -n 2 -rdp 4 --apply sum
  2:   2.7778 % |=====
  3:   5.5556 % |===========
  4:   8.3333 % |================
@@ -56,6 +56,8 @@ You can change the output to show a different number of decimal places (default 
 
 You can also change the output to show the counts.
 The module is trying every combination of output, treating each die as distinguishable.
+Note that if you have a weighted die, the counts can be floating point values,
+in that case it is possible to use `--result-decimal-place` to control the number of decimal places shown.
 ```
 ➔ python dice_distro.py -d 6 -n 2 --show-counts --apply sum
  2: 1 |=====
@@ -709,7 +711,7 @@ The above is the equvalent in saying:
 
 ### Two Ways to Roll Two Sets of D6, Summing Then Taking Max
 ```
-➔ python dice_distro.py -d 6 -n 4 -pdp 4 --apply sum 2 max
+➔ python dice_distro.py -d 6 -n 4 -rdp 4 --apply sum 2 max
  2:   0.0772 % |
  3:   0.6173 % |=
  4:   2.0833 % |====
@@ -723,7 +725,7 @@ The above is the equvalent in saying:
 12:   5.4784 % |==========
 ```
 ```
-➔ python dice_distro.py -d 6 -n 4 -pdp 4 --apply slice-apply 2 sum max
+➔ python dice_distro.py -d 6 -n 4 -rdp 4 --apply slice-apply 2 sum max
  2:   0.0772 % |
  3:   0.6173 % |=
  4:   2.0833 % |====
@@ -738,11 +740,7 @@ The above is the equvalent in saying:
 ```
 
 ### Weighted Dice
-Since this program uses enumeration to calculate the distribution,
-weighted dice can't simply be added with a parameter with weights using floating points values.
-The weights must be integers as they are just considered as being counted extra times.
-
-The following example shows a weighted D6.
+The following example shows a weighted D6. The weights can be integers or floats.
 ```
 ➔ python dice_distro.py -d 6 --die-weights 6 5 4 3 2 1
 1:  28.57 % |=========================================================
@@ -965,7 +963,7 @@ An example of simulating 100000 rolls of ten D30, taking the two largest values 
 Ten D30's has `30^10` or `5.904900e+14` distinct outcomes if you treat each die as distinguishable.
 Enumerating all the outcomes would take quite a while.
 ```
-➔ python dice_distro.py -d 30 -n 10 -pdp 3 --apply select -1 -2 sum --simulate 100000
+➔ python dice_distro.py -d 30 -n 10 -rdp 3 --apply select -1 -2 sum --simulate 100000
 20:   0.001 % |
 21:   0.003 % |
 22:   0.007 % |

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -99,12 +99,14 @@ echo "Starting Test with $python_exe" && \
     $python_exe $dice_distro_file $test_params -d 10 -n 2 --die-start 0 --die-step 10 && \
     $python_exe $dice_distro_file $test_params -n 2 --die-values 0 10 100 -1000 && \
     $python_exe $dice_distro_file $test_params -d 6 -n 2 --die-weights 6 5 4 3 2 1 --apply sum && \
+    $python_exe $dice_distro_file $test_params -d 6 -n 2 --die-weights 6.1 5.2 4.3 3.4 2.5 1.6 --apply sum && \
     # Test custom multi-die type options
     $python_exe $dice_distro_file $test_params --multi-die-sides 12 8 6 && \
     $python_exe $dice_distro_file $test_params --multi-die-sides 4 3 2 --multi-die-start -1 0 1 --multi-die-step 3 2 1 && \
     $python_exe $dice_distro_file $test_params --multi-die-sides 4 3 2 --multi-die-values 0 1 2 3 10 20 30 100 200 && \
     $python_exe $dice_distro_file $test_params --multi-die-sides 2 3 4 --multi-die-weights 1 2 3 4 5 6 7 8 9 && \
     $python_exe $dice_distro_file $test_params --multi-die-sides 2 3 4 --multi-die-values 9 8 7 6 5 4 3 2 1 --multi-die-weights 1 2 3 4 5 6 7 8 9 && \
+    $python_exe $dice_distro_file $test_params --multi-die-sides 2 3 4 --multi-die-values 9 8 7 6 5 4 3 2 1 --multi-die-weights 1.9 2.8 3.7 4.6 5.5 6.4 7.3 8.2 9.1 && \
     # Test file save and load with distrobution product
     $python_exe $dice_distro_file $test_params -d 6 -n 2 --save /tmp/2d6.json && \
     $python_exe $dice_distro_file $test_params --load /tmp/2d6.json /tmp/2d6.json --apply sum && \
@@ -113,11 +115,13 @@ echo "Starting Test with $python_exe" && \
     $python_exe $dice_distro_file $test_params --simulate 10000 -d 10 -n 2 --die-start 0 --die-step 10 && \
     $python_exe $dice_distro_file $test_params --simulate 10000 -n 2 --die-values 0 10 100 -1000 && \
     $python_exe $dice_distro_file $test_params --simulate 10000 -d 6 -n 2 --die-weights 6 5 4 3 2 1 --apply sum && \
+    $python_exe $dice_distro_file $test_params --simulate 10000 -d 6 -n 2 --die-weights 6.1 5.2 4.3 3.4 2.5 1.6 --apply sum && \
     $python_exe $dice_distro_file $test_params --simulate 10000 --multi-die-sides 12 8 6 && \
     $python_exe $dice_distro_file $test_params --simulate 10000 --multi-die-sides 4 3 2 --multi-die-start -1 0 1 --multi-die-step 3 2 1 && \
     $python_exe $dice_distro_file $test_params --simulate 10000 --multi-die-sides 4 3 2 --multi-die-values 0 1 2 3 10 20 30 100 200 && \
     $python_exe $dice_distro_file $test_params --simulate 10000 --multi-die-sides 2 3 4 --multi-die-weights 1 2 3 4 5 6 7 8 9 && \
     $python_exe $dice_distro_file $test_params --simulate 10000 --multi-die-sides 2 3 4 --multi-die-values 9 8 7 6 5 4 3 2 1 --multi-die-weights 1 2 3 4 5 6 7 8 9 && \
+    $python_exe $dice_distro_file $test_params --simulate 10000 --multi-die-sides 2 3 4 --multi-die-values 9 8 7 6 5 4 3 2 1 --multi-die-weights 1.9 2.8 3.7 4.6 5.5 6.4 7.3 8.2 9.1 && \
     # Test display options
     $python_exe $dice_distro_file $test_params_with_output -d 6 -n 2 && \
     $python_exe $dice_distro_file $test_params_with_output -d 6 -n 2 --apply sum --show-counts && \


### PR DESCRIPTION
Updated the readme and the tests to run cases with floating point values for weights

Also got rid of some magic values related to die value generation.
All the defaults are defined at the top of the file and referenced anywhere they are needed. (even though they all have the same value).
This is because they are used for different things.
This way if they to change them in the future, we can. although I don't see why we would.