### PR TITLE
 Small runtime optimizations (variable lookup speeds)

### DIFF
--- a/dice_distro.py
+++ b/dice_distro.py
@@ -82,18 +82,30 @@ BASIC_OPERATIONS = set(
     key for key, value in OPERATIONS_DICT.items() if value is not None
 )
 
+def rounding_half_up(xx,
+    # the following are done for runtime optimizations
+    Decimal=decimal.Decimal,
+    quantize=decimal.Decimal.quantize,
+    one=decimal.Decimal('1'),
+    rounding=decimal.ROUND_HALF_UP,
+):
+    return quantize(Decimal(xx), one,rounding=rounding)
+
+def rounding_half_down(xx,
+    # the following are done for runtime optimizations
+    Decimal=decimal.Decimal,
+    quantize=decimal.Decimal.quantize,
+    one=decimal.Decimal('1'),
+    rounding=decimal.ROUND_HALF_DOWN,
+):
+    return quantize(Decimal(xx), one,rounding=rounding)
+
 ROUNDING_OPTIONS = {
     'r-ceil': math.ceil,
     'r-floor': math.floor,
     'r-truncate': int,
-    'r-half-up': lambda xx: decimal.Decimal(xx).quantize(
-        decimal.Decimal('1'),
-        rounding = decimal.ROUND_HALF_UP,
-    ),
-    'r-half-down': lambda xx: decimal.Decimal(xx).quantize(
-        decimal.Decimal('1'),
-        rounding = decimal.ROUND_HALF_DOWN,
-    ),
+    'r-half-up': rounding_half_up,
+    'r-half-down': rounding_half_down,
 }
 
 # set of operations that support an if-block

--- a/dice_distro.py
+++ b/dice_distro.py
@@ -24,16 +24,48 @@ def prod_values(xx,
 ):
     return reduce(mul, xx, 1)
 
+"""
+The following are definitions of "basic operations"
+used for dice output manipulation
+"""
+def _id(xx): return xx
+def _sum(xx,sum=sum): return sum(xx),
+def _min(xx,min=min): return min(xx),
+def _max(xx,max=max): return max(xx),
+def _prod(xx, prod_values=prod_values): return prod_values(xx),
+def _sort(xx,tuple=tuple,sorted=sorted): return tuple(sorted(xx))
+
+def _bit_or(xx,
+    # the following are done for runtime optimizations
+    or_=operator.or_,
+    reduce=functools.reduce,
+):
+    return reduce(or_, xx, 0),
+
+def _bit_xor(xx,
+    # the following are done for runtime optimizations
+    xor=operator.xor,
+    reduce=functools.reduce,
+):
+    return reduce(xor, xx),
+
+def _bit_and(xx,
+    # the following are done for runtime optimizations
+    and_=operator.and_,
+    reduce=functools.reduce,
+):
+    return reduce(and_, xx),
+
 OPERATIONS_DICT = {
-    'id':lambda xx: xx,
-    'sum':lambda xx: (sum(xx),),
-    'min':lambda xx: (min(xx),),
-    'max':lambda xx: (max(xx),),
-    'sort':lambda xx: tuple(sorted(xx)),
-    'prod':lambda xx: (prod_values(xx),),
-    'bit-or':lambda xx: (functools.reduce(operator.or_, xx, 0),),
-    'bit-xor':lambda xx: (functools.reduce(operator.xor, xx),),
-    'bit-and':lambda xx: (functools.reduce(operator.and_, xx),),
+    'id':_id,
+    'sum':_sum,
+    'min':_min,
+    'max':_max,
+    'sort':_sort,
+    'prod':_prod,
+    'bit-or': _bit_or,
+    'bit-xor': _bit_xor,
+    'bit-and': _bit_and,
     'add': None, # This will get defined later if used
     'scale': None, # This will get defined later if used
     'exp': None, # This will get defined later if used

--- a/dice_distro.py
+++ b/dice_distro.py
@@ -126,13 +126,20 @@ ELSE_ABLE_OPERATIONS = set([
     'bound',
 ])
 
+def _ne(aa, bb, cc=None): return aa != bb
+def _eq(aa, bb, cc=None): return aa == bb
+def _gt(aa, bb, cc=None): return aa > bb
+def _ge(aa, bb, cc=None): return aa >= bb
+def _lt(aa, bb, cc=None): return aa < bb
+def _le(aa, bb, cc=None): return aa <= bb
+
 BASIC_COMPARE_DICT = {
-    'ne':lambda aa, bb, cc=None: aa != bb,
-    'eq':lambda aa, bb, cc=None: aa == bb,
-    'gt':lambda aa, bb, cc=None: aa > bb,
-    'ge':lambda aa, bb, cc=None: aa >= bb,
-    'lt':lambda aa, bb, cc=None: aa < bb,
-    'le':lambda aa, bb, cc=None: aa <= bb,
+    'ne': _ne,
+    'eq': _eq,
+    'gt': _gt,
+    'ge': _ge,
+    'lt': _lt,
+    'le': _le,
 }
 
 LOGIC_START_KEYWORD = 'if'


### PR DESCRIPTION
Depending on the dice roll configuration many thousand (or even millions) of dice input will be processed.
Due to a design decision there really isn't any algorithmic optimization that can be made (and also maintain the flexibility of the program).

With that in mind, any function that is going to be ran in the time intensive loop in the program will have optimizations in the area of variable look up speeds.
The key optimization was to make any global or builtin lookup be a local lookup. In some cases a lookup in the function closure was the best that can be done since the function signature of the actual function to be ran wouldn't of supported extra keywords.

This is inspired by the python documentation at the end of the [`itertools`](https://docs.python.org/3.6/library/itertools.html#itertools-recipes) library at the end of the recipes sections.
This idea is also talked about in a [stackoverflow post](https://stackoverflow.com/a/6725261/1517202) which eludes to the fact that this is probably no longer as big as an issue as it used to be.

Another optimization implemented is to remove `lambda` functions in any part that would have been called in the time intensive loop. Though it seems the improvements are minor based of [this](https://stackoverflow.com/a/26541027/1517202). I also looked into this:
```python
In [1]: a1=lambda: sum(range(10))

In [2]: def a2(): return sum(range(10))

In [3]: a3 = lambda sum=sum,range=range:sum(range(10))

In [4]: def a4(sum=sum,range=range): return sum(range(10))

In [5]: %timeit a1()
The slowest run took 9.81 times longer than the fastest. This could mean that an intermediate result is being cached.
1000000 loops, best of 3: 432 ns per loop

In [6]: %timeit a2()
The slowest run took 4.11 times longer than the fastest. This could mean that an intermediate result is being cached.
1000000 loops, best of 3: 431 ns per loop

In [7]: %timeit a3()
The slowest run took 4.12 times longer than the fastest. This could mean that an intermediate result is being cached.
1000000 loops, best of 3: 412 ns per loop

In [8]: %timeit a4()
1000000 loops, best of 3: 418 ns per loop
```

Another runtime preformance article [here](https://wiki.python.org/moin/PythonSpeed/PerformanceTips).